### PR TITLE
Linux build fix

### DIFF
--- a/dlls/Makefile
+++ b/dlls/Makefile
@@ -7,7 +7,7 @@ pb.dll: ${OFS}
 	${CPP} -shared  -Wl,--kill-at -o pb.dll ${OFS}
 	strip -s pb.dll
 pb_i686.so: ${OFS} pb.map
-	${CPP} -shared -Wl,--version-script=pb.map -o pb_i686.so -static-libgcc -L. ${OFS}
+	${CPP} -shared -Wl,--version-script=pb.map -o pb_i686.so -L. ${OFS}
 	strip -R .sym pb_i686.so
 pb.map:
 	grep LINK_ENTITY_TO_CLASS *.cpp | perl genmap.pl > pb.map

--- a/dlls/build.sh
+++ b/dlls/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 if  test `uname -s` = Linux ; then
-make pb_i686.so CC=gcc-2.95 CPP=g++-2.95 OSFLAGS="-fPIC -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp"
+make pb_i686.so CC=/opt/gcc-2.95/bin/gcc CPP=/opt/gcc-2.95/bin/g++ OSFLAGS="-fPIC -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp"
 else
 make pb.dll CC=gcc CPP=g++ OSFLAGS="-DWIN32 -D_WINDOWS"
 fi

--- a/dlls/genmap.pl
+++ b/dlls/genmap.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-print "{\n\tglobal:\n\t\tGiveFnptrsToDll;\n\t\tGetEntityAPI;\n\t\tGetEntityAPI2;\n\t\tServer_GetBlendingInterface;\n";
+print "VERS_1.1 {\n\tglobal:\n\t\tGiveFnptrsToDll;\n\t\tGetEntityAPI;\n\t\tGetEntityAPI2;\n\t\tServer_GetBlendingInterface;\n";
 while(<STDIN>) {
 	chomp;
 	/\( *(.*),/;


### PR DESCRIPTION
Using the CentOS virtual machine I had to make a couple of modifications to get it to compile.

```
g++: unrecognized option `-static-libgcc'
```

I don't know if this is a warning or error, but I removed the flag.

```
/usr/bin/ld:pb.map:1: parse error in VERSION script
```

I modified the perl script that spits out the map file to include the version script. 

The makefile had to be modified as well to use gcc 2.95. 